### PR TITLE
Router pages

### DIFF
--- a/client/src/components/header.jsx
+++ b/client/src/components/header.jsx
@@ -11,7 +11,10 @@ function Header() {
         <NavLink to={'/about'} className={({ isActive }) => (isActive ? "active-link" : "")}>
           about
         </NavLink>
-        <NavLink to={'/account'} className={({ isActive }) => (isActive ? "active-link" : "")}>
+        {/* TODO: put the logged in user's Id in href here */}
+        {/* TODO: conditionally renter the account link to only show when logged in. */}
+        {/* TODO: when not logged in, show a log in link */}
+        <NavLink to={'/account/userId'} className={({ isActive }) => (isActive ? "active-link" : "")}>
           account
         </NavLink>
         <div className="vertical-line"></div>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -9,8 +9,11 @@ import "./index.css";
 //Importing pages
 import HomePage from "./pages/Home.jsx";
 import Login from "./pages/Login.jsx";
+import AboutPage from "./pages/About.jsx";import AccountPage from "./pages/account.jsx";
+import CartPage from "./pages/Cart.jsx";
 
 import { ThemeProvider } from "@material-tailwind/react";
+
 
 const router = createBrowserRouter([
   {
@@ -25,6 +28,18 @@ const router = createBrowserRouter([
       {
         path: "/login",
         element: <Login />,
+      },
+      {
+        path: "/about",
+        element: <AboutPage />,
+      },
+      {
+        path: "/account/:userId",
+        element: <AccountPage />,
+      },
+      {
+        path: "/cart",
+        element: <CartPage />,
       },
       // Add more routes here...
     ],

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -1,0 +1,9 @@
+function AboutPage() {
+  return (
+    <>
+    <h2>About page</h2>
+    </>
+  )
+};
+
+export default AboutPage;

--- a/client/src/pages/Account.jsx
+++ b/client/src/pages/Account.jsx
@@ -1,0 +1,9 @@
+function AccountPage() {
+  return (
+    <>
+    <h2>Account page</h2>
+    </>
+  )
+};
+
+export default AccountPage;

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -1,0 +1,9 @@
+function CartPage() {
+  return (
+    <>
+    <h2>Cart page</h2>
+    </>
+  )
+};
+
+export default CartPage;


### PR DESCRIPTION
Added blank pages for about, account, and cart.
Added routes for those pages to the router in main.jsx.

The route for account is currently /account/:userId
In the header, the link to account pages is currently /account/userId, and needs to be changed to use the current user's id, which I believe can be accessed with context.

![image](https://github.com/user-attachments/assets/c7c36237-ad48-4a5e-b1e3-afc408b4cbff)
