### PR TITLE
ScrollToTop functioning

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import { ProductsProvider } from "./utils/ProductsContext.jsx";
 
 import Header from "./components/header";
 import Footer from "./components/footer";
+import ScrollToTop from "./utils/scroll-to-top.jsx";
 
 const httpLink = createHttpLink({
   uri: "/graphql",
@@ -36,6 +37,7 @@ function App() {
     <>
       <ApolloProvider client={client}>
         <ProductsProvider>
+          <ScrollToTop />
           <Header />
 
           <main>

--- a/client/src/utils/scroll-to-top.jsx
+++ b/client/src/utils/scroll-to-top.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+function ScrollToTop() {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Added a component to scroll to the top of the page whenever the route changes. Without it, the page stays scrolled at its current position when changing pages (since it's technically single-page and not reloading like an html site)