### PR TITLE
Stripe return, Stock update, Receipt page

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,1 +1,0 @@
-VITE_API_URL=https://isabelles-bead-shop.onrender.com

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://isabelles-bead-shop.onrender.com

--- a/client/src/components/CheckoutButton.jsx
+++ b/client/src/components/CheckoutButton.jsx
@@ -18,9 +18,8 @@ const CheckoutButton = ({ cartItems }) => {
       quantity: item.quantity,
     }));
 
-
     try {
-      const response = await fetch(`${window.location.origin}/create-checkout-session`, {
+      const response = await fetch(`${window.location.origin.replace('3000', '3001')}/create-checkout-session`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/client/src/components/CheckoutButton.jsx
+++ b/client/src/components/CheckoutButton.jsx
@@ -18,10 +18,9 @@ const CheckoutButton = ({ cartItems }) => {
       quantity: item.quantity,
     }));
 
-    const apiUrl = import.meta.env.VITE_API_URL;
 
     try {
-      const response = await fetch(`${apiUrl}/create-checkout-session`, {
+      const response = await fetch(`${window.location.origin}/create-checkout-session`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/client/src/components/CheckoutButton.jsx
+++ b/client/src/components/CheckoutButton.jsx
@@ -1,101 +1,63 @@
 import { loadStripe } from "@stripe/stripe-js";
-import {
-  EmbeddedCheckout,
-  EmbeddedCheckoutProvider,
-} from "@stripe/react-stripe-js";
-import { useCallback, useRef, useState, useEffect } from "react";
 
-export default function CheckoutButton({ cartItems }) {
+const CheckoutButton = ({ cartItems }) => {
   const stripePromise = loadStripe(
     "pk_test_51Q2G162MBbXhKSWl5DEAnWv59xawhXsLx1ezVYquN9XdN3PkOB8yt71UBZbzXwCZVJIjYIfQZmxkT2GS4ekGLVq900JJH1kTY7"
   );
-  const [showCheckout, setShowCheckout] = useState(false);
-  const [stripeItems, setStripeItems] = useState([]);
-  const modalRef = useRef(null);
 
-  // update stripeItems when cartItems changes
-  useEffect(() => {
-    // Group items by ID and calculate quantities
-    const groupedItems = cartItems.reduce((acc, item) => {
-      if (acc[item._id]) {
-        acc[item._id].quantity += 1;
-      } else {
-        acc[item._id] = { ...item, quantity: item.quantity };
-      }
-      console.log(acc);
-      return acc;
-    }, {});
-
-    // Convert grouped items into an array of objects that Stripe can understand
-    const newStripeItems = Object.values(groupedItems).map((item) => {
-      return {
-        price_data: {
-          currency: "usd",
-          product_data: {
-            name: item.name,
-          },
-          unit_amount: item.price,
+  // Create a Stripe checkout session and redirect
+  const redirectToCheckout = async () => {
+    const stripeItems = cartItems.map((item) => ({
+      price_data: {
+        currency: "usd",
+        product_data: {
+          name: item.name,
         },
-        quantity: item.quantity,
-      };
-    });
-    setStripeItems(newStripeItems);
-  }, [cartItems]);
-
-  const fetchClientSecret = useCallback(() => {
-    // create a checkout session on the server
-    return fetch("http://localhost:3001/create-checkout-session", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+        unit_amount: item.price,
       },
-      body: JSON.stringify({ items: stripeItems }),
-    })
-      .then((res) => res.json())
-      .then((data) => data.clientSecret);
-  }, [stripeItems]);
+      quantity: item.quantity,
+    }));
 
-  const options = { fetchClientSecret };
+    const apiUrl = import.meta.env.VITE_API_URL;
 
-  const handleCheckoutClick = () => {
-    setShowCheckout(true);
-    modalRef.current?.showModal();
-    document.body.classList.add("overflow-hidden");
+    try {
+      const response = await fetch(`${apiUrl}/create-checkout-session`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ items: stripeItems }),
+      });
+
+      const session = await response.json();
+
+      if (session.sessionId) {
+        const stripe = await stripePromise;
+        // Ensure stripe instance is loaded
+        const { error } = await stripe.redirectToCheckout({
+          sessionId: session.sessionId,
+        });
+
+        if (error) {
+          console.error("Error redirecting to checkout:", error);
+        }
+      }
+    } catch (error) {
+      console.error("Error redirecting to checkout:", error);
+    }
   };
 
-  const handleCloseModal = () => {
-    setShowCheckout(false);
-    modalRef.current?.close();
-    document.body.classList.remove("overflow-hidden");
-  };
-
-  // TODO: Button style required, the modal has a button too
   return (
     <div id="checkout">
       <button
-        onClick={handleCheckoutClick}
-        disabled={stripeItems.length === 0}
-        className={`btn-1 ${stripeItems.length === 0 ? "opacity-0" : ""}`}
+        onClick={redirectToCheckout}
+        disabled={cartItems.length === 0}
+        className={`btn-1 ${cartItems.length === 0 ? "opacity-0" : ""}`}
       >
         Checkout
       </button>
-      <dialog ref={modalRef} className="w-auto bg-blue-100">
-        {showCheckout && (
-          <div>
-            <EmbeddedCheckoutProvider stripe={stripePromise} options={options}>
-              <EmbeddedCheckout />
-            </EmbeddedCheckoutProvider>
-          </div>
-        )}
-        <form method="dialog" className="bg-blue-100 p-1">
-          <button
-            onClick={handleCloseModal}
-            className={`bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded`}
-          >
-            Close
-          </button>
-        </form>
-      </dialog>
     </div>
   );
-}
+};
+
+export default CheckoutButton;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -14,9 +14,9 @@ import AccountPage from "./pages/Account.jsx";
 import Cart from "./pages/Cart.jsx";
 import ProductPage from "./pages/Product.jsx";
 import AdminPage from "./pages/Admin.jsx";
+import ReturnPage from "./pages/Return.jsx";
 
 import { ThemeProvider } from "@material-tailwind/react";
-
 
 const router = createBrowserRouter([
   {
@@ -51,7 +51,11 @@ const router = createBrowserRouter([
       {
         path: "/admin",
         element: <AdminPage />,
-      }
+      },
+      {
+        path: "/return",
+        element: <ReturnPage />,
+      },
       // Add more routes here...
     ],
   },

--- a/client/src/pages/Cart.jsx
+++ b/client/src/pages/Cart.jsx
@@ -12,47 +12,8 @@ export default function Cart() {
       <section className="cart-section">
         <h2>Shopping cart</h2>
         <ShoppingCart cartItems={cartItems} setCartItems={setCartItems} />
-        <CheckoutButton cartItems={cartItems}/>
-
-        {/* TODO: create one of these div's for each item in the cart, using correct data in {} */}
-        {/* <div className="cart-item">
-          <figure className="product-img-cart">
-            <img
-              src="images/tempPictures/defaultProductImage.jpg"
-              className="crop-img"
-            ></img>
-          </figure>
-          <div className="item-text-box">
-            <Link to="/product/PUTproductIdHERE" className="bold">
-              Product Name
-            </Link>
-            <p>Quantity: 1</p>
-            <p>$5.00 each</p>
-          </div>
-          <button className="btn-del">x</button>
-        </div>
-
-        <div className="cart-item">
-          <figure className="product-img-cart">
-            <img
-              src="images/tempPictures/defaultProductImage.jpg"
-              className="crop-img"
-            ></img>
-          </figure>
-          <div className="item-text-box">
-            <Link to="/product/PUTproductIdHERE" className="bold">
-              Product Name
-            </Link>
-            <p>Quantity: 2</p>
-            <p>$5.00 each</p>
-          </div>
-          <button className="btn-del">x</button>
-        </div>
-
-        <p className="total">TOTAL: $15.00</p>
-        <button className="btn-1">Check Out</button> */}
+        <CheckoutButton cartItems={cartItems} />
       </section>
     </>
   );
 }
-

--- a/client/src/pages/Return.jsx
+++ b/client/src/pages/Return.jsx
@@ -12,7 +12,7 @@ const ReturnPage = () => {
     const sessionId = query.get("session_id");
 
     if (sessionId) {
-      fetch(`${window.location.origin}/retrieve-checkout-session/${sessionId}`)
+      fetch(`${window.location.origin.replace('3000', '3001')}/create-checkout-session/${sessionId}`)
         .then((response) => {
           if (!response.ok) {
             throw new Error("Network response was not ok");

--- a/client/src/pages/Return.jsx
+++ b/client/src/pages/Return.jsx
@@ -12,7 +12,7 @@ const ReturnPage = () => {
     const sessionId = query.get("session_id");
 
     if (sessionId) {
-      fetch(`${window.location.origin.replace('3000', '3001')}/create-checkout-session/${sessionId}`)
+      fetch(`${window.location.origin.replace('3000', '3001')}/retrieve-checkout-session/${sessionId}`)
         .then((response) => {
           if (!response.ok) {
             throw new Error("Network response was not ok");
@@ -20,6 +20,7 @@ const ReturnPage = () => {
           return response.json();
         })
         .then((data) => {
+          console.log("response data", data); // Log the parsed JSON data
           setSession(data);
           setLoading(false); // Set loading to false after successful fetch
         })

--- a/client/src/pages/Return.jsx
+++ b/client/src/pages/Return.jsx
@@ -10,10 +10,9 @@ const ReturnPage = () => {
   useEffect(() => {
     const query = new URLSearchParams(location.search);
     const sessionId = query.get("session_id");
-    const apiUrl = import.meta.env.VITE_API_URL;
 
     if (sessionId) {
-      fetch(`${apiUrl}/retrieve-checkout-session/${sessionId}`)
+      fetch(`${window.location.origin}/retrieve-checkout-session/${sessionId}`)
         .then((response) => {
           if (!response.ok) {
             throw new Error("Network response was not ok");

--- a/client/src/pages/Return.jsx
+++ b/client/src/pages/Return.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+const ReturnPage = () => {
+  const [session, setSession] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    const query = new URLSearchParams(location.search);
+    const sessionId = query.get("session_id");
+    const apiUrl = import.meta.env.VITE_API_URL;
+
+    if (sessionId) {
+      fetch(`${apiUrl}/retrieve-checkout-session/${sessionId}`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        })
+        .then((data) => {
+          setSession(data);
+          setLoading(false); // Set loading to false after successful fetch
+        })
+        .catch((error) => {
+          console.error("Error fetching session:", error);
+          setError(error.message);
+          setLoading(false); // Set loading to false on error
+        });
+    } else {
+      setLoading(false);
+    }
+  }, [location]);
+
+  // Display depending true/false loading, error, or session data states
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
+
+  if (!session) {
+    return <p>No session data found.</p>;
+  }
+
+  return (
+    <div>
+      <h1>Order Receipt</h1>
+      <p>Payment Status: {session.payment_status}</p>
+      <h2>Items Purchased:</h2>
+      <ul>
+        {session.line_items.data.map((item) => (
+          <li key={item.id}>
+            {item.quantity} x {item.description} - $
+            {(item.amount_total / 100).toFixed(2)}
+          </li>
+        ))}
+      </ul>
+      <p>Total Amount: ${(session.amount_total / 100).toFixed(2)}</p>
+    </div>
+  );
+};
+
+export default ReturnPage;

--- a/client/src/pages/Return.jsx
+++ b/client/src/pages/Return.jsx
@@ -1,18 +1,29 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { useMutation } from "@apollo/client";
+import { UPDATE_STOCK } from "../utils/mutations";
 
 const ReturnPage = () => {
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const location = useLocation();
+  const [updateStock] = useMutation(UPDATE_STOCK);
 
   useEffect(() => {
     const query = new URLSearchParams(location.search);
     const sessionId = query.get("session_id");
 
-    if (sessionId) {
-      fetch(`${window.location.origin.replace('3000', '3001')}/retrieve-checkout-session/${sessionId}`)
+    // Flag to check if update to stock is required
+    const stockUpdated = localStorage.getItem(`stockUpdated_${sessionId}`);
+
+    if (sessionId ) {
+      fetch(
+        `${window.location.origin.replace(
+          "3000",
+          "3001"
+        )}/retrieve-checkout-session/${sessionId}`
+      )
         .then((response) => {
           if (!response.ok) {
             throw new Error("Network response was not ok");
@@ -23,16 +34,34 @@ const ReturnPage = () => {
           console.log("response data", data); // Log the parsed JSON data
           setSession(data);
           setLoading(false); // Set loading to false after successful fetch
+
+          // Check if stock has already been updated
+          !stockUpdated && updateStock({
+            variables: {
+              products: data.line_items.data.map((item) => ({
+                name: item.description,
+                quantity: item.quantity,
+              })),
+            },
+          })
+            .then(() => {
+              console.log("Stock updated successfully");
+              // Set flag in localStorage to prevent multiple updates on refresh
+              localStorage.setItem(`stockUpdated_${sessionId}`, 'true');
+            })
+            .catch((error) => {
+              console.error("Error updating stock:", error);
+            });
         })
         .catch((error) => {
           console.error("Error fetching session:", error);
           setError(error.message);
-          setLoading(false); // Set loading to false on error
+          setLoading(false); 
         });
     } else {
       setLoading(false);
     }
-  }, [location]);
+  }, []);
 
   // Display depending true/false loading, error, or session data states
 

--- a/client/src/pages/Return.jsx
+++ b/client/src/pages/Return.jsx
@@ -17,7 +17,7 @@ const ReturnPage = () => {
     // Flag to check if update to stock is required
     const stockUpdated = localStorage.getItem(`stockUpdated_${sessionId}`);
 
-    if (sessionId ) {
+    if (sessionId) {
       fetch(
         `${window.location.origin.replace(
           "3000",
@@ -36,27 +36,28 @@ const ReturnPage = () => {
           setLoading(false); // Set loading to false after successful fetch
 
           // Check if stock has already been updated
-          !stockUpdated && updateStock({
-            variables: {
-              products: data.line_items.data.map((item) => ({
-                name: item.description,
-                quantity: item.quantity,
-              })),
-            },
-          })
-            .then(() => {
-              console.log("Stock updated successfully");
-              // Set flag in localStorage to prevent multiple updates on refresh
-              localStorage.setItem(`stockUpdated_${sessionId}`, 'true');
+          !stockUpdated &&
+            updateStock({
+              variables: {
+                products: data.line_items.data.map((item) => ({
+                  name: item.description,
+                  quantity: item.quantity,
+                })),
+              },
             })
-            .catch((error) => {
-              console.error("Error updating stock:", error);
-            });
+              .then(() => {
+                console.log("Stock updated successfully");
+                // Set flag in localStorage to prevent multiple updates on refresh
+                localStorage.setItem(`stockUpdated_${sessionId}`, "true");
+              })
+              .catch((error) => {
+                console.error("Error updating stock:", error);
+              });
         })
         .catch((error) => {
           console.error("Error fetching session:", error);
           setError(error.message);
-          setLoading(false); 
+          setLoading(false);
         });
     } else {
       setLoading(false);
@@ -78,19 +79,52 @@ const ReturnPage = () => {
   }
 
   return (
-    <div>
-      <h1>Order Receipt</h1>
-      <p>Payment Status: {session.payment_status}</p>
-      <h2>Items Purchased:</h2>
-      <ul>
+    <div className="max-w-2xl mx-auto p-8 bg-white shadow-lg rounded-lg my-10">
+      <h1 className="mb-6">
+        Order Receipt
+      </h1>
+
+      <p className="text-lg text-gray-700 mb-4">
+        Thank you, <span className="font-semibold text-gray-900">{session.customer_details.name}</span>, for your purchase! We appreciate your business.
+      </p>
+
+      <p className="text-lg text-gray-700 mb-4">
+        <span className="font-semibold">Payment Status:</span>{" "}
+        <span
+          className={`${
+            session.payment_status === "paid"
+              ? "text-green-600"
+              : "text-red-600"
+          }`}
+        >
+          {session.payment_status}
+        </span>
+      </p>
+
+      <h2 className="text-xl font-semibold text-gray-800 mb-4">
+        Items Purchased:
+      </h2>
+
+      <ul className="space-y-4">
         {session.line_items.data.map((item) => (
-          <li key={item.id}>
-            {item.quantity} x {item.description} - $
-            {(item.amount_total / 100).toFixed(2)}
+          <li
+            key={item.id}
+            className="flex justify-between items-center bg-gray-100 p-4 rounded-lg"
+          >
+            <span className="font-medium text-gray-900">
+              {item.quantity} x {item.description}
+            </span>
+            <span className="text-gray-800">
+              ${(item.amount_total / 100).toFixed(2)}
+            </span>
           </li>
         ))}
       </ul>
-      <p>Total Amount: ${(session.amount_total / 100).toFixed(2)}</p>
+
+      <div className="mt-6 text-xl font-semibold text-gray-900 border-t pt-4">
+        <span>Total Amount: </span>
+        <span>${(session.amount_total / 100).toFixed(2)}</span>
+      </div>
     </div>
   );
 };

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -107,3 +107,9 @@ export const ADD_REVIEW = gql`
     }
   }
 `;
+
+export const UPDATE_STOCK = gql`
+  mutation UpdateStock($products: [UpdateStockInput!]!) {
+    updateStock(products: $products)
+  }
+`;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "concurrently": "^9.0.1"
+    "concurrently": "^9.0.1",
+    "cross-env": "^7.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "E-commerce site for a small jewelry shop",
   "main": "index.js",
   "scripts": {
-    "start": "node server/server.js",
+    "start": "cross-env NODE_ENV=production node server/server.js",
     "dev": "concurrently \"cd server && npm run watch\" \"cd client && npm run dev\"",
     "install": "cd server && npm install && cd ../client && npm install",
     "build": "cd client && npm run build",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "cross-env NODE_ENV=production node server.js",
     "watch": "nodemon server.js --watch server.js",
     "seed": "node seeders/seed.js"
   },
@@ -24,6 +24,7 @@
     "stripe": "^16.11.0"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "nodemon": "^3.1.4"
   }
 }

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -88,7 +88,37 @@ const resolvers = {
       ).populate([{ path: "username", strictPopulate: false }]);
       return updProduct;
     },
+
+    //* Order Mutations
+    //********************************* */
+    updateStock: async (_, { products }) => {
+      try {
+        for (const product of products) {
+          console.log("product.name", product.name);
+          // Assuming you have a way to map Stripe line product IDs to MongoDB ObjectIds
+          const productId = await mapStripeIdToMongoId(product.name);
+          console.log("productId", productId);
+          console.log("productId._id", productId._id);
+          await Product.findByIdAndUpdate(productId, {
+            $inc: { stock: -product.quantity },
+          });
+          
+        }
+        return true;
+      } catch (error) {
+        console.error("Error updating stock:", error);
+        return false;
+      }
+    },
   },
 };
 
+const mapStripeIdToMongoId = async (productName) => {
+  const product = await Product.findOne({ name: productName });
+  if (!product) {
+    console.error(`Product with name ${productName} not found`);
+    return null;
+  }
+  return product._id;
+};
 module.exports = resolvers;

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -16,6 +16,7 @@ type Mutation {
     deleteProduct(_id:ID!): Product
     addOrder(products: [ID]!): Order
     addReview(_id:ID!, ReviewDetails: ReviewDetailsInput ): Product
+    updateStock(products: [UpdateStockInput!]!): Boolean
 }
 type Auth {
     token: ID!,
@@ -72,5 +73,10 @@ type Order {
 type Checkout {
     session: ID
 }
+
+input UpdateStockInput {
+    name: String!
+    quantity: Int!
+  }
 `;
 module.exports = typeDefs;

--- a/server/server.js
+++ b/server/server.js
@@ -65,7 +65,7 @@ const startApolloServer = async () => {
       res.json({ sessionId: session.id });
     } catch (error) {
       console.error("Error creating checkout session:", error);
-      res.status(500).send("Internal Server Error");
+      res.status(500).json({ error: 'Internal Server Error' });
     }
   });
 

--- a/server/server.js
+++ b/server/server.js
@@ -50,8 +50,7 @@ const startApolloServer = async () => {
   // STRIPE CHECKOUT ROUTES
   app.post("/create-checkout-session", async (req, res) => {
     try {
-      const baseUrl = process.env.NODE_ENV === 'development' ? process.env.DEV_URL : process.env.PROD_URL;
-
+      console.log("line_items", req.body.items);
       const session = await stripe.checkout.sessions.create({
         payment_method_types: ["card"],
         line_items: req.body.items,
@@ -59,8 +58,8 @@ const startApolloServer = async () => {
         shipping_address_collection: {
           allowed_countries: ["US", "CA"], // Specify the allowed countries for shipping
         },
-        success_url: `${baseUrl}/return?success=true&session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: `${baseUrl}/cart`,
+        success_url: `${req.headers.origin}/return?success=true&session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${req.headers.origin}/cart`,
       });
       res.json({ sessionId: session.id });
     } catch (error) {

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ const { authMiddleware } = require("./utils/auth");
 
 const { typeDefs, resolvers } = require("./schemas");
 const db = require("./config/connection");
+const { add } = require("./models/reviews");
 const PORT = process.env.PORT || 3001;
 const app = express();
 const server = new ApolloServer({
@@ -16,8 +17,11 @@ const server = new ApolloServer({
 
 const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 
-// TODO: make sure this is connecting to the front-end on LIVE server
-app.use(cors({ origin: 'http://localhost:3000' }));
+const corsOptions = {
+  origin: process.env.NODE_ENV === 'development' ? process.env.DEV_URL : process.env.PROD_RL,
+};
+
+app.use(cors(corsOptions));
 
 const startApolloServer = async () => {
   await server.start();
@@ -46,39 +50,37 @@ const startApolloServer = async () => {
   // STRIPE CHECKOUT ROUTES
   app.post("/create-checkout-session", async (req, res) => {
     try {
-      const { items } = await req.body;
+      const baseUrl = process.env.NODE_ENV === 'development' ? process.env.DEV_URL : process.env.PROD_URL;
 
-      if (!items) {
-        throw new Error("items is missing or invalid");
-      }
-  
-      console.log("Received items:", items); 
-  
       const session = await stripe.checkout.sessions.create({
-        ui_mode: "embedded",
-        line_items: items,
+        payment_method_types: ["card"],
+        line_items: req.body.items,
         mode: "payment",
         shipping_address_collection: {
-          allowed_countries: ['US', 'CA'], // Add any country codes where you ship
+          allowed_countries: ["US", "CA"], // Specify the allowed countries for shipping
         },
-        return_url: `${req.headers.origin}/`, // TODO: create a /success page or something to redirect to after payment
+        success_url: `${baseUrl}/return?success=true&session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${baseUrl}/cart`,
       });
-      res.json({ clientSecret: session.client_secret });
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Unable to create checkout session" });
+      res.json({ sessionId: session.id });
+    } catch (error) {
+      console.error("Error creating checkout session:", error);
+      res.status(500).send("Internal Server Error");
     }
   });
 
-  app.get("/session-status", async (req, res) => {
-    const session = await stripe.checkout.sessions.retrieve(
-      req.query.session_id
-    );
+  app.get("/retrieve-checkout-session/:sessionId", async (req, res) => {
+    const sessionId = req.params.sessionId;
 
-    res.send({
-      status: session.status,
-      customer_email: session.customer_details.email,
-    });
+    try {
+      const session = await stripe.checkout.sessions.retrieve(sessionId, {
+        expand: ["line_items"],
+      });
+      res.json(session);
+    } catch (error) {
+      console.error("Error retrieving session:", error);
+      res.status(500).json({ error: error.message });
+    }
   });
 
   db.once("open", () => {


### PR DESCRIPTION
# MAYBE TEST THE BRANCH ON LIVE FIRST!!
(only tested on local devmode)


<img width="442" alt="image" src="https://github.com/user-attachments/assets/969b3a9e-ec3d-4958-91b0-ddd2ce55067f">
Displays successful orders.

Updates the stock in database.  IT IS USING the "name" field to match.  This is because the item on the stripe side is not defined.  

(my current understanding) We would need to look into migrating and syncing the databases with stripe.
But, for now it will grab the "description" the stripe item, then check that against the names in our db to .findOne( {name: description} )

there is a flag in local storage that will flip when the update has occurred for each checkout Session ID.   I think in the future you would have to have a flag on the server side to avoid any funny business (since you can just reset the localstorage and refresh the page to trigger another update event.  Im sure theres Redux or some nonsense thatll work as well.

Quick and dirty tailwind to pad it out.